### PR TITLE
Fix Kafka source links: trunk → 4.2.0 tag

### DIFF
--- a/website/blog/2026-04-02-kafka-kip-1034-dlq/index.md
+++ b/website/blog/2026-04-02-kafka-kip-1034-dlq/index.md
@@ -109,10 +109,10 @@ dlqProducer.send(dlqRecord).get();
 `RecordQueue.addRawRecords()` 先把 raw records 放進 queue，接著 `updateHead()` 會呼叫 `recordDeserializer.deserialize(processorContext, raw)`；之後 `StreamTask.process()` 才從 `partitionGroup.nextRecord(...)` 取出 record，交給 `doProcess()` 傳進 source node。也就是說，deserialization 確實發生在 record 進入 topology 之前。
 
 參考：
-- [RecordQueue.addRawRecords()](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java#L976-L985)
-- [RecordQueue.updateHead()](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java#L1114-L1126)
-- [StreamTask.process()](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java#L3497-L3533)
-- [StreamTask.doProcess()](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java#L3654-L3694)
+- [RecordQueue.addRawRecords()](https://github.com/apache/kafka/blob/4.2.0/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java)
+- [RecordQueue.updateHead()](https://github.com/apache/kafka/blob/4.2.0/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java)
+- [StreamTask.process()](https://github.com/apache/kafka/blob/4.2.0/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java)
+- [StreamTask.doProcess()](https://github.com/apache/kafka/blob/4.2.0/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java)
 :::
 
 `ManualDlqHandler.java` 示範的就是這條路：


### PR DESCRIPTION
## Summary

- 文章 :::info 區塊中 4 個 Kafka 原始碼連結原先指向 `trunk`，行號會隨 commit 飄移
- 改為指向 `4.2.0` tag（去掉行號，因無法在不查原始碼的情況下確認 4.2.0 的正確行號）

## Review 完整結果

此 PR 源自對文章與程式碼的全面 review，除上述連結問題外，其餘均通過：

**文章內容**
- 所有程式碼 snippet 與實際原始檔吻合（可接受的敘述性簡化除外）
- KIP-1034 技術主張正確：`ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG`、`LogAndContinueExceptionHandler` 行為、`__streams.errors.*` headers、tx-safe 說明均有程式碼佐證

**測試邏輯**
- `after/` TopologyTestDriver 4 個 test cases 邏輯正確
- `before/` unit tests（Mockito + TopologyTestDriver）邏輯正確
- `before/` integration test（Testcontainers + cp-kafka:7.6.1）在 GitHub Actions ubuntu-latest 可正常執行

**CI**
- `website` job：Docusaurus build，文章只有外部連結，`onBrokenLinks: 'throw'` 不影響
- `dlq-demo` job：`./gradlew test` 執行兩個 subproject，版本與 API 使用均正確

https://claude.ai/code/session_01SwoFVx8JrbqkTPkB1LWvYy